### PR TITLE
switch inline style to use height and width instead

### DIFF
--- a/public/javascripts/Manuscript.js
+++ b/public/javascripts/Manuscript.js
@@ -8,7 +8,7 @@ Manuscript.bboxToStyle = function(bbox_str) {
   arr = bbox_str.split(" ");
   left_pos = "left:"+arr[1]+"px; ";
   top_pos = "top:"+arr[2]+"px; ";
-  right_pos = "right:"+arr[3]+"px; ";
-  bottom_pos = "bottom:"+arr[4]+"px; ";
-  return left_pos + top_pos + right_pos + bottom_pos;
+  width = "width:"+(arr[3]-arr[1])+"px; ";
+  height = "height:"+(arr[4]-arr[2])+"px; ";
+  return left_pos + top_pos + width + height;
 };

--- a/spec/javascripts/ManuscriptSpec.js
+++ b/spec/javascripts/ManuscriptSpec.js
@@ -3,7 +3,7 @@ describe("Manuscript", function() {
   describe ("class methods", function() {
       it("#bboxToStyle", function() {
           result = Manuscript.bboxToStyle("bbox 197 272 249 281");
-          expect(result).toEqual("left:197px; top:272px; right:249px; bottom:281px; ");
+          expect(result).toEqual("left:197px; top:272px; width:52px; height:9px; ");
 
       });
 


### PR DESCRIPTION
Hi! I stumbled across your library and am really glad I did. I noticed your inline style application applies a `right` and `bottom` property. When I pull up your sample letter it looks like this in Chrome:
![letter_html 2](https://cloud.githubusercontent.com/assets/1226418/17271058/a4632c76-563f-11e6-8647-18cd8d1c1b49.jpg)

I think you are intending to set the bounding box for each word, in which case instead of `right` and `bottom`, the CSS properties `width` and `height` should be used, so that properties like `outline` and `background` will be able to determine the box dimensions. When I apply the changes in this pull request, the letter looks like this:

![letter_html](https://cloud.githubusercontent.com/assets/1226418/17271065/f041bf54-563f-11e6-86a6-d702f9d4810e.jpg)

From what I can see of the code it looks like that's more what you intended for the effect of the library. If not, feel free to close/ingore this PR.

Thanks again!
